### PR TITLE
ワークフローを分離: 自動レビューと@claudeメンションを別ファイルに

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,31 +9,26 @@ on:
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
-  # @claude メンションで応答（PR のコメントのみ、普通の Issue では動作しない）
-  pull_request_review_comment:
-    types: [created]
-  issue_comment:
-    types: [created]
+  # @claude メンションは claude.yml で処理
 
 # 同じPRで新しいコミットがpushされた場合、実行中のレビューをキャンセル
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
+    # ドラフトPRと develop→main の Release PR はスキップ
+    if: |
+      github.event.pull_request.draft == false &&
+      !(github.event.pull_request.head.ref == 'develop' && github.event.pull_request.base.ref == 'main')
+
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
       id-token: write
-
-    # ドラフトPRと develop→main の Release PR はスキップ、コメントの場合は @claude メンションが必要
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false && !(github.event.pull_request.head.ref == 'develop' && github.event.pull_request.base.ref == 'main')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
 
     steps:
       - name: Checkout repository
@@ -54,7 +49,7 @@ jobs:
           # 自動レビュー用プロンプト
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
             Note: The PR branch is already checked out in the current working directory.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize]
     # オプション: 特定のファイル変更時のみ実行
     # paths:
     #   - "src/**/*.ts"
@@ -27,7 +27,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
+      issues: read
       id-token: write
 
     steps:
@@ -41,10 +42,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-          # 追加コミット時に同じコメントを更新する
-          use_sticky_comment: true
 
           # 自動レビュー用プロンプト
           prompt: |
@@ -67,5 +64,4 @@ jobs:
             必ず日本語でレビューを実施し、具体的で建設的なフィードバックを提供してください。
 
           # PRコメントと差分表示用のツールを許可
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
     # オプション: 特定のファイル変更時のみ実行
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,56 @@
+name: Claude Code
+
+on:
+  # @claude メンションで応答
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  # Issue に @claude が含まれている場合
+  issues:
+    types: [opened, assigned]
+
+# 同じ Issue/PR で重複実行を防止
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude:
+    # @claude メンションが含まれている場合のみ実行
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # CI結果を読み取るために必要
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+          # CI結果を読み取る権限を追加
+          additional_permissions: |
+            actions: read
+
+          # @claude メンションのコメント内容に従って実行
+          # prompt を指定しない場合、コメント内容が指示として使用される

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,7 +8,7 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
-  # Issue に @claude が含まれている場合
+  # Issue に @claude が含まれている場合、または claude がアサインされた場合
   issues:
     types: [opened, assigned]
 
@@ -24,20 +24,20 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
 
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
       actions: read # CI結果を読み取るために必要
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -46,7 +46,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # CI結果を読み取る権限を追加
           additional_permissions: |


### PR DESCRIPTION
## 概要
PR #6 の内容を参考に、ワークフローを役割ごとに分離しました。

## 変更内容

### 新規追加: `claude.yml`
- `@claude` メンション専用ワークフロー
- Issue / PR コメント / レビューコメントで `@claude` に応答
- CI結果を読み取る権限を追加

### 変更: `claude-code-review.yml`
- 自動レビュー専用に変更
- `@claude` メンション関連のトリガーを削除（`claude.yml` に移動）
- if 条件を簡略化

## ワークフローの役割分担

| ファイル | トリガー | 役割 |
|---------|---------|------|
| `claude-code-review.yml` | PR 作成・更新 | 自動レビュー |
| `claude.yml` | `@claude` メンション | Issue/PR/レビューコメントで応答 |