### PR TITLE
fix: 追加コミット時の自動レビューを無効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
     # オプション: 特定のファイル変更時のみ実行
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
## Summary
- `synchronize` イベントを削除
- 追加コミット時には自動レビューを実行しない
- PR 作成時（opened）、ドラフト解除時（ready_for_review）、再オープン時（reopened）のみ自動レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)