### PR TITLE
refactor: PR と Issue でワークフローを分離

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,26 +9,31 @@ on:
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
-  # @claude メンションは claude.yml で処理
+  # PR 上での @claude メンション
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
 
-# 同じPRで新しいコミットがpushされた場合、実行中のレビューをキャンセル
+# 同じPRで重複実行を防止（Claude の応答コメントでキャンセルされないよう false に設定）
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   claude-review:
-    # ドラフトPRと develop→main の Release PR はスキップ
+    # PR イベント、または PR 上での @claude メンション
     if: |
-      github.event.pull_request.draft == false &&
-      !(github.event.pull_request.head.ref == 'develop' && github.event.pull_request.base.ref == 'main')
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false && !(github.event.pull_request.head.ref == 'develop' && github.event.pull_request.base.ref == 'main')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude'))
 
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -46,10 +51,10 @@ jobs:
           # 追加コミット時に同じコメントを更新する
           use_sticky_comment: true
 
-          # 自動レビュー用プロンプト
+          # レビュー用プロンプト
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             Note: The PR branch is already checked out in the current working directory.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,29 +1,23 @@
-name: Claude Code
+name: Claude Code (Issue)
 
 on:
-  # @claude メンションで応答
+  # Issue での @claude メンション
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
-  # Issue に @claude が含まれている場合、または claude がアサインされた場合
+  # Issue 作成時に @claude が含まれている場合、または claude がアサインされた場合
   issues:
     types: [opened, assigned]
 
-# 同じ Issue/PR で重複実行を防止（Claude の応答コメントでキャンセルされないよう false に設定）
+# 同じ Issue で重複実行を防止（Claude の応答コメントでキャンセルされないよう false に設定）
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
   claude:
-    # @claude メンションが含まれている場合のみ実行
+    # Issue での @claude メンション（PR は claude-code-review.yml で処理）
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
 
     runs-on: ubuntu-latest
@@ -31,7 +25,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
       id-token: write
       actions: read # CI結果を読み取るために必要
 


### PR DESCRIPTION
## Summary

### claude-code-review.yml（PR 専用）
- PR 自動レビュー（opened, ready_for_review, reopened）
- PR 上での `@claude` メンション
- 詳細なレビュープロンプトを使用
- `permissions: write` に変更

### claude.yml（Issue 専用）
- Issue での `@claude` メンションのみ
- PR 関連トリガーを削除
- コメント内容をそのまま指示として使用

## 動作

| 操作 | 処理するワークフロー | プロンプト |
|-----|-------------------|----------|
| PR 作成 | claude-code-review.yml | 詳細レビュー |
| PR 上で `@claude` | claude-code-review.yml | 詳細レビュー |
| Issue で `@claude` | claude.yml | コメント内容 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)